### PR TITLE
Fix max_iterations limits in settings json schema

### DIFF
--- a/sparklink/files/settings_jsonschema.json
+++ b/sparklink/files/settings_jsonschema.json
@@ -57,12 +57,11 @@
       "title": "The maximum number of iterations to run even if convergence has not been reached",
       "default": 100,
       "examples": [
-        0.0001,
-        0.00001,
-        1e-6
+        10,
+        150
       ],
-      "maximum": 0.05,
-      "minimum": 1e-12
+      "maximum": 200,
+      "minimum": 1
     },
     "unique_id_column_name": {
       "$id": "#/properties/unique_id_column_name",


### PR DESCRIPTION
Copy and paste error from `em_convergence` max/min values. Assume 200 is a sensible max given 100 is the default. 1 seems the logical minimum.

```
The details of the error are as follows:
10 is greater than the maximum of 0.05

Failed validating 'maximum' in schema['properties']['max_iterations']:
    {'$id': '#/properties/max_iterations',
     'default': 100,
     'examples': [0.0001, 1e-05, 1e-06],
     'maximum': 0.05,
     'minimum': 1e-12,
     'title': 'The maximum number of iterations to run even if convergence '
              'has not been reached',
     'type': 'number'}

On instance['max_iterations']:
    10
```