### PR TITLE
Consistent num_iterations throughout

### DIFF
--- a/sparklink/__init__.py
+++ b/sparklink/__init__.py
@@ -96,7 +96,10 @@ class Sparklink:
         df_gammas = add_gammas(df_comparison, self.settings, self.spark)
         return run_expectation_step(df_gammas, self.params, self.settings, self.spark)
 
-    def get_scored_comparisons(self, num_iterations=20):
+    def get_scored_comparisons(self, num_iterations=None):
+        
+        if (num_iterations is None):
+            num_iterations=self.settings["max_iterations"]
 
         df_comparison = self._get_df_comparison()
 

--- a/sparklink/files/settings_jsonschema.json
+++ b/sparklink/files/settings_jsonschema.json
@@ -55,9 +55,9 @@
       "$id": "#/properties/max_iterations",
       "type": "number",
       "title": "The maximum number of iterations to run even if convergence has not been reached",
-      "default": 100,
+      "default": 10,
       "examples": [
-        10,
+        20,
         150
       ],
       "maximum": 200,


### PR DESCRIPTION
- Changes json schema to default `max_iterations` of 10 to match the default `num_iterations` in `iterate()`
- `get_scored_comparisons()` falls back on `max_iterations` from the settings, unless `num_iterations` is explicitly provided

Closes #74 
